### PR TITLE
Do not require value to implement `Clone`

### DIFF
--- a/src/clone.rs
+++ b/src/clone.rs
@@ -58,6 +58,7 @@ fn larger_map_can_be_cloned() {
 }
 
 #[derive(Clone)]
+#[allow(dead_code)]
 struct Foo {
     _m: Map<u64>,
 }

--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -30,7 +30,7 @@ impl<V> Drop for Map<V> {
     }
 }
 
-impl<V: Clone> Map<V> {
+impl<V> Map<V> {
     /// Make it.
     ///
     /// # Panics
@@ -74,6 +74,15 @@ impl<V: Clone> Map<V> {
         m
     }
 
+    /// Return capacity.
+    #[inline]
+    #[must_use]
+    pub const fn capacity(&self) -> usize {
+        self.layout.size() / mem::size_of::<Option<V>>()
+    }
+}
+
+impl <V: Clone> Map<V> {
     /// Make it and prepare all keys with some value set.
     ///
     /// This is a more expensive operation that `with_capacity`, because it has
@@ -94,14 +103,7 @@ impl<V: Clone> Map<V> {
             m.initialized = true;
         }
         m
-    }
-
-    /// Return capacity.
-    #[inline]
-    #[must_use]
-    pub const fn capacity(&self) -> usize {
-        self.layout.size() / mem::size_of::<Option<V>>()
-    }
+    }    
 }
 
 #[test]

--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -82,7 +82,7 @@ impl<V> Map<V> {
     }
 }
 
-impl <V: Clone> Map<V> {
+impl<V: Clone> Map<V> {
     /// Make it and prepare all keys with some value set.
     ///
     /// This is a more expensive operation that `with_capacity`, because it has
@@ -103,7 +103,7 @@ impl <V: Clone> Map<V> {
             m.initialized = true;
         }
         m
-    }    
+    }
 }
 
 #[test]

--- a/src/index.rs
+++ b/src/index.rs
@@ -21,7 +21,7 @@
 use crate::Map;
 use std::ops::{Index, IndexMut};
 
-impl<V: Clone> Index<usize> for Map<V> {
+impl<V> Index<usize> for Map<V> {
     type Output = V;
 
     #[inline]
@@ -30,7 +30,7 @@ impl<V: Clone> Index<usize> for Map<V> {
     }
 }
 
-impl<V: Clone> IndexMut<usize> for Map<V> {
+impl<V> IndexMut<usize> for Map<V> {
     #[inline]
     fn index_mut(&mut self, key: usize) -> &mut V {
         self.get_mut(key).expect("No entry found for key")

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -26,9 +26,9 @@ impl<'a, V: Clone + 'a> Iterator for Iter<'a, V> {
 
     /// This is an implementation of the `next` function that returns the next item in an iterator if it
     /// exists, or `None` if the end of the iterator has been reached.
-    /// 
+    ///
     /// Returns:
-    /// 
+    ///
     /// The `next` function returns an `Option` that contains a tuple of `(i, p)` where `i` is the index of
     /// the item and `p` is a reference to the item. If there are no more items to iterate over, it returns
     /// `None`.

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -100,7 +100,7 @@ impl<'a, V: Copy> IntoIterator for &'a Map<V> {
     }
 }
 
-impl<V: Clone> Map<V> {
+impl<V> Map<V> {
     /// Make an iterator over all items.
     ///
     /// # Panics

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -41,7 +41,7 @@ impl<V> Iterator for Keys<V> {
     }
 }
 
-impl<V: Clone> Map<V> {
+impl<V> Map<V> {
     /// Make an iterator over all keys.
     ///
     /// # Panics

--- a/src/map.rs
+++ b/src/map.rs
@@ -21,7 +21,7 @@
 use crate::Map;
 use std::ptr;
 
-impl<V: Clone> Map<V> {
+impl<V> Map<V> {
     /// Is it empty?
     #[inline]
     #[must_use]

--- a/src/next_key.rs
+++ b/src/next_key.rs
@@ -20,7 +20,7 @@
 
 use crate::Map;
 
-impl<V: Clone> Map<V> {
+impl<V> Map<V> {
     /// Get the next key available for insertion.
     ///
     /// # Panics

--- a/src/values.rs
+++ b/src/values.rs
@@ -56,7 +56,7 @@ impl<V: Copy> Iterator for IntoValues<V> {
     }
 }
 
-impl<V: Clone> Map<V> {
+impl<V> Map<V> {
     /// Make an iterator over all values.
     ///
     /// # Panics


### PR DESCRIPTION
I've discovered that most operations on `emap::Map` do not require `Clone` to be implemented for the value type.

In fact, [only one constructor](https://github.com/yegor256/emap/blob/8677015e2b3e3afff13363a0e2009dc48eb5dd20/src/ctors.rs#L87) relies on this constraint.

This pull request removes the `Clone` requirement from all operations except for the one constructor mentioned above.