### PR TITLE
implement avx/avx2 with_capacity_some

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-cpu=native"]

--- a/benches/with_capacity.rs
+++ b/benches/with_capacity.rs
@@ -18,10 +18,18 @@ macro_rules! bench_capacity_some {
                 })
             });
 
-            #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
             group.bench_with_input(BenchmarkId::new("sse", el), el, |b, el| {
                 b.iter(|| {
                     black_box(Map::<$type>::with_capacity_some_sse(
+                        black_box(*el),
+                        black_box($default_value),
+                    ));
+                })
+            });
+
+            group.bench_with_input(BenchmarkId::new("avx", el), el, |b, el| {
+                b.iter(|| {
+                    black_box(Map::<$type>::with_capacity_some_avx(
                         black_box(*el),
                         black_box($default_value),
                     ));
@@ -57,12 +65,20 @@ fn bench_u32(c: &mut Criterion) {
     bench_capacity_some!(c, u32, 0xDEADBEEF_u32, "u32");
 }
 
+fn bench_i64(c: &mut Criterion) {
+    bench_capacity_some!(c, i64, 0xDEADBEEF_i64, "i64");
+}
+
+fn bench_u64(c: &mut Criterion) {
+    bench_capacity_some!(c, u64, 0xDEADBEEF_u64, "u64");
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default()
         .warm_up_time(std::time::Duration::from_millis(500))
         .measurement_time(std::time::Duration::from_secs(2))
         .sample_size(20);
-    targets = bench_i8, bench_i16, bench_i32, bench_u8, bench_u16, bench_u32
+    targets = bench_i8, bench_i16, bench_i32, bench_i64, bench_u8, bench_u16, bench_u32, bench_u64
 }
 criterion_main!(benches);

--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -99,6 +99,8 @@ macro_rules! impl_with_capacity_some_sse {
             /// use sse2 vector registers for filling. It works faster than
             /// `with_capacity_some`.
             ///
+            /// Supported types: `i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`.
+            ///
             /// # Panics
             ///
             /// May panic if out of memory.
@@ -106,20 +108,18 @@ macro_rules! impl_with_capacity_some_sse {
             #[must_use]
             pub fn with_capacity_some_sse(cap: usize, value: $type) -> Self {
                 let mut m = Self::with_capacity(cap);
-                m.init_sse(value);
+                if is_x86_feature_detected!("sse2") {
+                    m.init_sse(value);
+                } else {
+                    for k in 0..cap {
+                        m.insert(k, value.clone());
+                    }
+                }
                 #[cfg(debug_assertions)]
                 {
                     m.initialized = true;
                 }
                 m
-            }
-        }
-
-        #[cfg(not(all(target_arch = "x86_64", target_feature = "sse2")))]
-        impl Map<$type> {
-            pub fn with_capacity_some_sse(cap: usize, value: $type) -> Self {
-                log::warn!("SSE2 not available, using fallback");
-                Self::with_capacity_some(cap, value)
             }
         }
     };
@@ -128,9 +128,56 @@ macro_rules! impl_with_capacity_some_sse {
 impl_with_capacity_some_sse!(i8);
 impl_with_capacity_some_sse!(i16);
 impl_with_capacity_some_sse!(i32);
+impl_with_capacity_some_sse!(i64);
 impl_with_capacity_some_sse!(u8);
 impl_with_capacity_some_sse!(u16);
 impl_with_capacity_some_sse!(u32);
+impl_with_capacity_some_sse!(u64);
+
+macro_rules! impl_with_capacity_some_avx {
+    ($type:ty) => {
+        impl Map<$type> {
+            /// Make it and prepare all keys with some value set using avx/avx2 registers.
+            ///
+            /// This method is implemented for primitive types and allows you to
+            /// use avx/avx2 vector registers for filling. It works faster than
+            /// `with_capacity_some`. Please note that performance may vary on
+            /// different systems.
+            ///
+            /// Supported types: `i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`.
+            ///
+            /// # Panics
+            ///
+            /// May panic if out of memory.
+            #[inline]
+            #[must_use]
+            pub fn with_capacity_some_avx(cap: usize, value: $type) -> Self {
+                let mut m = Self::with_capacity(cap);
+                if is_x86_feature_detected!("avx2") || is_x86_feature_detected!("avx") {
+                    m.init_avx(value);
+                } else {
+                    for k in 0..cap {
+                        m.insert(k, value.clone());
+                    }
+                }
+                #[cfg(debug_assertions)]
+                {
+                    m.initialized = true;
+                }
+                m
+            }
+        }
+    };
+}
+
+impl_with_capacity_some_avx!(i8);
+impl_with_capacity_some_avx!(i16);
+impl_with_capacity_some_avx!(i32);
+impl_with_capacity_some_avx!(i64);
+impl_with_capacity_some_avx!(u8);
+impl_with_capacity_some_avx!(u16);
+impl_with_capacity_some_avx!(u32);
+impl_with_capacity_some_avx!(u64);
 
 #[test]
 fn calculates_size_of_memory() {
@@ -194,6 +241,19 @@ fn init_with_some() {
 }
 
 #[test]
+fn init_with_some_sse() {
+    let value = 13131_i32;
+    let size = 127;
+    let m: Map<i32> = Map::<i32>::with_capacity_some_sse(size, value);
+
+    for i in 0..size {
+        assert_eq!(*m.get(i).unwrap(), value);
+    }
+    assert_eq!(m.len(), size);
+    assert_eq!(m.capacity(), size);
+}
+
+#[test]
 fn init_with_some_sse_neg() {
     let value = -13131_i32;
     let size = 127;
@@ -203,38 +263,31 @@ fn init_with_some_sse_neg() {
         assert_eq!(*m.get(i).unwrap(), value);
     }
     assert_eq!(m.len(), size);
+    assert_eq!(m.capacity(), size);
 }
 
-#[cfg(test)]
-macro_rules! test_sse_impl {
-    ($type:ty, $value:expr) => {
-        paste::item! {
-            #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
-            #[test]
-            fn [<test_sse_ $type>]() {
-                let sizes: [usize; 8] = [1, 2, 3, 4, 5, 13, 16, 25];
-                for size in sizes {
-                    let m: Map<$type> = Map::<$type>::with_capacity_some_sse(size, $value);
+#[test]
+fn init_with_some_avx() {
+    let value = 13131_i32;
+    let size = 127;
+    let m: Map<i32> = Map::<i32>::with_capacity_some_avx(size, value);
 
-                    for i in 0..size {
-                        assert_eq!(*m.get(i).unwrap(), $value);
-                    }
-                    assert_eq!(m.len(), size);
-                }
-            }
-        }
-    };
+    for i in 0..size {
+        assert_eq!(*m.get(i).unwrap(), value);
+    }
+    assert_eq!(m.len(), size);
+    assert_eq!(m.capacity(), size);
 }
 
-#[cfg(test)]
-test_sse_impl!(i8, 42_i8);
-#[cfg(test)]
-test_sse_impl!(i16, 1234_i16);
-#[cfg(test)]
-test_sse_impl!(i32, 0x11223344_i32);
-#[cfg(test)]
-test_sse_impl!(u8, 0xFF_u8);
-#[cfg(test)]
-test_sse_impl!(u16, 0xABCD_u16);
-#[cfg(test)]
-test_sse_impl!(u32, 0xDEADBEEF_u32);
+#[test]
+fn init_with_some_avx_neg() {
+    let value = -13131_i32;
+    let size = 127;
+    let m: Map<i32> = Map::<i32>::with_capacity_some_avx(size, value);
+
+    for i in 0..size {
+        assert_eq!(*m.get(i).unwrap(), value);
+    }
+    assert_eq!(m.len(), size);
+    assert_eq!(m.capacity(), size);
+}

--- a/src/values.rs
+++ b/src/values.rs
@@ -92,6 +92,17 @@ fn insert_and_jump_over_next() {
 }
 
 #[test]
+fn insert_and_not_seq() {
+    let mut m: Map<&str> = Map::with_capacity_none(16);
+    m.insert(0, "foo");
+    m.insert(12, "bar");
+    let mut values = m.into_values();
+    assert_eq!("foo", values.next().unwrap());
+    assert_eq!("bar", values.next().unwrap());
+    assert!(values.next().is_none());
+}
+
+#[test]
 fn count_them_all() {
     let mut m: Map<&str> = Map::with_capacity_none(16);
     m.insert(0, "one");


### PR DESCRIPTION
@yegor256 
I have implemented a constructor using avx/avx2 registers for primitive types.
Unfortunately, avx512 is only available in nightly, so I didn't implement it.

On my benchmarks, 'with_capacity_some_avx` showed similar performance in some places compared to `with_capacity_some_sse` and was sometimes even slower. However, I assume that the performance may vary significantly on different processors.