### PR TITLE
improve performance for values() keys() and with_capacity_some()

### DIFF
--- a/benches/compare_with_vec.rs
+++ b/benches/compare_with_vec.rs
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023 Yegor Bugayenko
+// SPDX-License-Identifier: MIT
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use emap::Map;
+
+fn compare_ctors(c: &mut Criterion) {
+    let mut group = c.benchmark_group(format!("compare_with_capacity_some"));
+    let sizes: [usize; 8] = [10, 100, 1000, 10_000, 25_000, 50_000, 75_000, 100_000];
+    for size in sizes.iter() {
+        group.bench_with_input(BenchmarkId::new("vec", size), size, |b, size| {
+            b.iter(|| {
+                black_box(
+                    Vec::with_capacity(black_box(*size))
+                        .resize(black_box(*size), black_box(42_i32)),
+                );
+            })
+        });
+
+        group.bench_with_input(BenchmarkId::new("map_std", size), size, |b, size| {
+            b.iter(|| {
+                black_box(Map::<i32>::with_capacity_some(
+                    black_box(*size),
+                    black_box(42_i32),
+                ));
+            })
+        });
+
+        group.bench_with_input(BenchmarkId::new("map_sse", size), size, |b, size| {
+            b.iter(|| {
+                black_box(Map::<i32>::with_capacity_some_sse(
+                    black_box(*size),
+                    black_box(42_i32),
+                ));
+            })
+        });
+    }
+
+    group.finish();
+}
+
+fn compare_insert(c: &mut Criterion) {
+    let mut group = c.benchmark_group(format!("compare_insert"));
+    let sizes: [usize; 8] = [10, 100, 1000, 10_000, 25_000, 50_000, 75_000, 100_000];
+    for size in sizes.iter() {
+        group.bench_with_input(BenchmarkId::new("vec", size), size, |b, size| {
+            let mut vec = Vec::with_capacity(*size);
+            b.iter(|| {
+                for _ in 0..*size {
+                    black_box(vec.push(black_box(42_i32)));
+                }
+            })
+        });
+
+        group.bench_with_input(BenchmarkId::new("map", size), size, |b, size| {
+            let mut map = Map::<i32>::with_capacity(*size);
+            b.iter(|| {
+                for i in 0..*size {
+                    black_box(map.insert(black_box(i), black_box(42_i32)));
+                }
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn compare_values(c: &mut Criterion) {
+    let mut group = c.benchmark_group(format!("compare_values"));
+    let sizes: [usize; 6] = [10, 100, 1000, 10_000, 25_000, 50_000];
+    for size in sizes.iter() {
+        group.bench_with_input(BenchmarkId::new("vec", size), size, |b, size| {
+            let mut vec = Vec::with_capacity(*size);
+            vec.resize(*size, 42_i32);
+            b.iter(|| {
+                let mut sum = 0;
+                for _ in 0..*size {
+                    for s in black_box(vec.iter()) {
+                        sum += black_box(*s);
+                    }
+                }
+                black_box(sum)
+            })
+        });
+
+        group.bench_with_input(BenchmarkId::new("map", size), size, |b, size| {
+            let map = Map::<i32>::with_capacity_some(*size, 42_i32);
+            b.iter(|| {
+                let mut sum = 0;
+                for _ in 0..*size {
+                    for s in black_box(map.values()) {
+                        sum += black_box(*s);
+                    }
+                }
+                black_box(sum)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn compare_keys(c: &mut Criterion) {
+    let mut group = c.benchmark_group(format!("compare_keys"));
+    let sizes: [usize; 6] = [10, 100, 1000, 10_000, 25_000, 50_000];
+    for size in sizes.iter() {
+        group.bench_with_input(BenchmarkId::new("vec", size), size, |b, size| {
+            let mut vec = Vec::with_capacity(*size);
+            vec.resize(*size, 42_i32);
+            b.iter(|| {
+                let mut sum = 0;
+                for _ in 0..*size {
+                    for s in black_box(vec.iter()) {
+                        sum += black_box(*s);
+                    }
+                }
+                black_box(sum)
+            })
+        });
+
+        group.bench_with_input(BenchmarkId::new("map", size), size, |b, size| {
+            let map = Map::<i32>::with_capacity_some(*size, 42_i32);
+            b.iter(|| {
+                let mut sum = 0;
+                for _ in 0..*size {
+                    for k in black_box(map.keys()) {
+                        sum += black_box(k);
+                    }
+                }
+                black_box(sum)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(2))
+        .measurement_time(std::time::Duration::from_secs(3))
+        .sample_size(20);
+    targets = compare_ctors, compare_insert, compare_values, compare_keys
+}
+criterion_main!(benches);

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -16,7 +16,6 @@ impl<'a, V: Clone + 'a> Iterator for Iter<'a, V> {
     /// the item and `p` is a reference to the item. If there are no more items to iterate over, it returns
     /// `None`.
     #[inline]
-    #[must_use]
     fn next(&mut self) -> Option<Self::Item> {
         while self.pos < self.max {
             let item = unsafe { &*self.head.add(self.pos) };
@@ -35,7 +34,6 @@ impl<'a, V: Clone + 'a> Iterator for IterMut<'a, V> {
     type Item = (usize, &'a mut V);
 
     #[inline]
-    #[must_use]
     fn next(&mut self) -> Option<Self::Item> {
         while self.pos < self.max {
             let item = unsafe { &mut *self.head.add(self.pos) };
@@ -54,7 +52,6 @@ impl<V: Clone> Iterator for IntoIter<V> {
     type Item = (usize, V);
 
     #[inline]
-    #[must_use]
     fn next(&mut self) -> Option<Self::Item> {
         while self.pos < self.max {
             let item = unsafe { &*self.head.add(self.pos) };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,11 +70,9 @@ pub struct IntoIter<V> {
     head: *mut Option<V>,
 }
 
-/// Iterator over the values of a [`Map`].
 pub struct Values<'a, V> {
-    max: usize,
-    pos: usize,
-    head: *mut Option<V>,
+    current: *const Option<V>,
+    end: *const Option<V>,
     _marker: PhantomData<&'a V>,
 }
 
@@ -87,9 +85,9 @@ pub struct IntoValues<V> {
 
 /// Iterator over the keys of a [`Map`].
 pub struct Keys<V> {
-    max: usize,
-    pos: usize,
-    head: *mut Option<V>,
+    start: *mut Option<V>,
+    current: *mut Option<V>,
+    end: *mut Option<V>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
@yegor256 
I've analyzed the existing implementations of the `Values` and `Keys` iterators and `with_capacity_some` constructor, comparing them with similar implementations in Rust's standard library.

## Performance Improvements:
### Constructor Optimization:
The `with_capacity_some` constructor has been significantly accelerated and now matches the performance of `with_capacity_some_sse`. I propose removing `with_capacity_some_sse` in the next PR since it's no longer needed.

### Iterator Optimizations:

For the `Values` iterator, I've reduced operations in `next()` calls, achieving performance comparable to `vec::Iter` (within 5% margin).

The `Keys` iterator now shows 10-15% better performance.

### Benchmarking:
I've added targeted benchmarks comparing our implementation with `Vec`, focusing specifically on the methods we're optimizing. These new benchmarks provide more focused measurements than our previous general benchmarks.

### Notes:
I'm not updating the `README.md` benchmarks in this PR because my local tests show significant variance with small datasets. However, I'm including benchmark results for larger datasets below:

Before changes (dataset sizes: [1024, 2048, 4096, 8192]):
![image1](https://github.com/user-attachments/assets/3f71bd4d-ad28-4f19-b931-c4730f74259c)

After changes (note rows 2 and 4 for key improvements):
![image2](https://github.com/user-attachments/assets/efb003df-0d79-4add-935b-a51a1f5e5a52)