### PR TITLE
Update benchmarks: migrate from vector to intmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ version = "0.0.0"
 dependencies = [
  "bincode",
  "criterion",
+ "intmap",
  "paste",
  "serde",
 ]
@@ -217,6 +218,12 @@ name = "hermit-abi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+
+[[package]]
+name = "intmap"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "210870d5399600055a955c020cc97e462203c234dc2b103b5da5d80fdbd5eed5"
 
 [[package]]
 name = "is-terminal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["memory", "map"]
 categories = ["data-structures", "memory-management"]
 
 [dependencies]
+intmap = "3.1.0"
 serde = { version = "1.0.185", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It's also faster than [`IntMap`][IntMap] (_we are working on this_).
 It's essentially [`Vec<Option<V>>`][Vec] with two extra features:
   1) `next_key()` with _O(1)_ complexity
   and
-  2) iterators with _O(M)_ complexity, where _M_ is the number of elements in \
+  2) iterators with _O(M)_ complexity, where _M_ is the number of elements in
 the array.
 
 You must know the total capacity upfront.

--- a/README.md
+++ b/README.md
@@ -50,27 +50,26 @@ The struct [`emap::Map`][Map] is designed as closely similar to
 ## Benchmark
 
 There is a summary of a simple benchmark, where we compared `emap::Map` with
-`Vec`, changing the total capacity `CAP` of them (horizontal axis).
+`Intmap`, changing the total capacity `CAP` of them (horizontal axis).
 We applied the same interactions
 ([`benchmark.rs`][benchmark])
 to them both and measured how fast they performed. In the following table,
-the numbers over 1.0 indicate performance gain of `Map` against `Vec`,
+the numbers over 1.0 indicate performance gain of `Map` against `IntMap`,
 while the numbers below 1.0 demonstrate performance loss.
 
 <!-- benchmark -->
 | | 4 | 16 | 256 | 4096 |
 | --- | --: | --: | --: | --: |
-| `i ∈ 0..CAP {M.insert(i, &"Hello, world!")}` |1.08 |1.89 |2.35 |2.14 |
-| `i ∈ 0..CAP {M.insert(i, &"大家好"); s ∈ M.values() {sum += s.len()}}` |1.20 |0.88 |0.34 |0.51 |
-| `i ∈ 0..CAP {M.insert(i, &42); s ∈ M.into_values() {sum += s}}` |1.45 |0.93 |0.51 |0.52 |
-| `i ∈ 0..CAP {M.insert(i, &42); s ∈ M.keys() {sum += s}}` |1.09 |0.58 |0.34 |0.51 |
-| `i ∈ 0..CAP {M.insert(i, &42); s ∈ M.values() {sum += s}}` |1.03 |0.57 |0.51 |0.51 |
-| `i ∈ 0..CAP {M.insert(i, &42)}; M.clear(); M.len();` |1.27 |1.84 |6.71 |7.61 |
-| `i ∈ 0..CAP {M.insert(i, &42)}; i ∈ CAP-1..0 {M.remove(&i)}` |1.13 |2.13 |2.01 |2.15 |
+| `i ∈ 0..CAP {M.insert(i, &"Hello, world!")}` |6.33 |16.46 |23.98 |24.08 |
+| `i ∈ 0..CAP {M.insert(i, &"大家好"); s ∈ M.values() {sum += s.len()}}` |4.59 |5.80 |1.02 |0.91 |
+| `i ∈ 0..CAP {M.insert(i, &42); s ∈ M.keys() {sum += s}}` |7.51 |7.03 |1.15 |0.90 |
+| `i ∈ 0..CAP {M.insert(i, &42); s ∈ M.values() {sum += s}}` |6.31 |6.13 |0.94 |0.76 |
+| `i ∈ 0..CAP {M.insert(i, &42)}; M.clear(); M.len();` |4.52 |8.74 |9.45 |10.67 |
+| `i ∈ 0..CAP {M.insert(i, &42)}; i ∈ CAP-1..0 {M.remove(&i)}` |5.32 |12.26 |15.57 |14.62 |
 
-The experiment was performed on 21-08-2023.
+The experiment was performed on 13-05-2025.
  There were 10000 repetition cycles.
- The entire benchmark took 423s.
+ The entire benchmark took 1201s.
 
 <!-- benchmark -->
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ It's by the order of magnitude faster than the standard
 It's also faster than [`IntMap`][IntMap] (_we are working on this_).
 
 It's essentially [`Vec<Option<V>>`][Vec] with two extra features:
-  1) `next_key()` with _O(1)_ complexity)
+  1) `next_key()` with _O(1)_ complexity
   and
-  2) iterators with _O(M)_ complexity, where _M_ is the number of elements in the array.
+  2) iterators with _O(M)_ complexity, where _M_ is the number of elements in \
+the array.
 
 You must know the total capacity upfront.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ It's by the order of magnitude faster than the standard
 It's also faster than [`IntMap`][IntMap] (_we are working on this_).
 
 It's essentially [`Vec<Option<V>>`][Vec] with two extra features:
+
   1) `next_key()` with _O(1)_ complexity
   and
   2) iterators with _O(M)_ complexity, where _M_ is the number of elements in

--- a/benches/compare_with_intmap.rs
+++ b/benches/compare_with_intmap.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023 Yegor Bugayenko
+// SPDX-License-Identifier: MIT
+
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use emap::Map;
 use intmap::IntMap;

--- a/benches/compare_with_intmap.rs
+++ b/benches/compare_with_intmap.rs
@@ -1,23 +1,25 @@
-// SPDX-FileCopyrightText: Copyright (c) 2023 Yegor Bugayenko
-// SPDX-License-Identifier: MIT
-
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use emap::Map;
+use intmap::IntMap;
+
+type IntMapI32 = IntMap<usize, i32>;
 
 fn compare_ctors(c: &mut Criterion) {
-    let mut group = c.benchmark_group(format!("compare_with_capacity_some"));
-    let sizes: [usize; 8] = [10, 100, 1000, 10_000, 25_000, 50_000, 75_000, 100_000];
+    let mut group = c.benchmark_group("compare_with_capacity_some");
+    let sizes: [usize; 5] = [10, 100, 1000, 10_000, 25_000];
+
     for size in sizes.iter() {
-        group.bench_with_input(BenchmarkId::new("vec", size), size, |b, size| {
+        group.bench_with_input(BenchmarkId::new("intmap", size), size, |b, size| {
             b.iter(|| {
-                black_box(
-                    Vec::with_capacity(black_box(*size))
-                        .resize(black_box(*size), black_box(42_i32)),
-                );
+                let mut map = IntMapI32::with_capacity(*size);
+                for i in 0..*size {
+                    map.insert(i, black_box(42_i32));
+                }
+                black_box(map);
             })
         });
 
-        group.bench_with_input(BenchmarkId::new("map_std", size), size, |b, size| {
+        group.bench_with_input(BenchmarkId::new("map", size), size, |b, size| {
             b.iter(|| {
                 black_box(Map::<i32>::with_capacity_some(
                     black_box(*size),
@@ -26,19 +28,19 @@ fn compare_ctors(c: &mut Criterion) {
             })
         });
     }
-
     group.finish();
 }
 
 fn compare_insert(c: &mut Criterion) {
-    let mut group = c.benchmark_group(format!("compare_insert"));
-    let sizes: [usize; 8] = [10, 100, 1000, 10_000, 25_000, 50_000, 75_000, 100_000];
+    let mut group = c.benchmark_group("compare_insert");
+    let sizes: [usize; 5] = [10, 100, 1000, 10_000, 25_000];
+
     for size in sizes.iter() {
-        group.bench_with_input(BenchmarkId::new("vec", size), size, |b, size| {
-            let mut vec = Vec::with_capacity(*size);
+        group.bench_with_input(BenchmarkId::new("intmap", size), size, |b, size| {
+            let mut map = IntMapI32::with_capacity(*size);
             b.iter(|| {
-                for _ in 0..*size {
-                    black_box(vec.push(black_box(42_i32)));
+                for i in 0..*size {
+                    black_box(map.insert(i, black_box(42_i32)));
                 }
             })
         });
@@ -52,21 +54,23 @@ fn compare_insert(c: &mut Criterion) {
             });
         });
     }
-
     group.finish();
 }
 
 fn compare_values(c: &mut Criterion) {
-    let mut group = c.benchmark_group(format!("compare_values"));
-    let sizes: [usize; 6] = [10, 100, 1000, 10_000, 25_000, 50_000];
+    let mut group = c.benchmark_group("compare_values");
+    let sizes: [usize; 5] = [10, 100, 1000, 10_000, 25_000];
+
     for size in sizes.iter() {
-        group.bench_with_input(BenchmarkId::new("vec", size), size, |b, size| {
-            let mut vec = Vec::with_capacity(*size);
-            vec.resize(*size, 42_i32);
+        group.bench_with_input(BenchmarkId::new("intmap", size), size, |b, size| {
+            let mut map = IntMapI32::with_capacity(*size);
+            for i in 0..*size {
+                map.insert(i, 42_i32);
+            }
             b.iter(|| {
                 let mut sum = 0;
                 for _ in 0..*size {
-                    for s in black_box(vec.iter()) {
+                    for s in black_box(map.values()) {
                         sum += black_box(*s);
                     }
                 }
@@ -87,22 +91,24 @@ fn compare_values(c: &mut Criterion) {
             });
         });
     }
-
     group.finish();
 }
 
 fn compare_keys(c: &mut Criterion) {
-    let mut group = c.benchmark_group(format!("compare_keys"));
-    let sizes: [usize; 6] = [10, 100, 1000, 10_000, 25_000, 50_000];
+    let mut group = c.benchmark_group("compare_keys");
+    let sizes: [usize; 5] = [10, 100, 1000, 10_000, 25_000];
+
     for size in sizes.iter() {
-        group.bench_with_input(BenchmarkId::new("vec", size), size, |b, size| {
-            let mut vec = Vec::with_capacity(*size);
-            vec.resize(*size, 42_i32);
+        group.bench_with_input(BenchmarkId::new("intmap", size), size, |b, size| {
+            let mut map = IntMapI32::with_capacity(*size);
+            for i in 0..*size {
+                map.insert(i, 42_i32);
+            }
             b.iter(|| {
                 let mut sum = 0;
                 for _ in 0..*size {
-                    for s in black_box(vec.iter()) {
-                        sum += black_box(*s);
+                    for k in black_box(map.keys()) {
+                        sum += black_box(k);
                     }
                 }
                 black_box(sum)
@@ -122,7 +128,6 @@ fn compare_keys(c: &mut Criterion) {
             });
         });
     }
-
     group.finish();
 }
 

--- a/tests/benchmark.rs
+++ b/tests/benchmark.rs
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
-// In order to run this single test from the command line:
-// $ cargo test --test benchmark -- --nocapture
-
 use emap::Map;
+use intmap::IntMap;
 use std::env;
 use std::time::{Duration, Instant};
 
 const CAP: usize = 10;
+type FastIntMap<'a> = IntMap<u64, &'a i32>;
+type FastIntMapStr<'a> = IntMap<u64, &'a str>;
 
 macro_rules! measure {
     ($total:expr, $e:expr) => {{
@@ -21,11 +21,11 @@ macro_rules! measure {
 }
 
 macro_rules! compare {
-    ($title:expr, $ret:expr, $total:expr, $eV:expr, $eM:expr) => {{
+    ($title:expr, $ret:expr, $total:expr, $eI:expr, $eM:expr) => {{
         $ret.push((
             $title,
             measure!($total, {
-                $eV(std::hint::black_box(&mut Vec::with_capacity(CAP)))
+                $eI(std::hint::black_box(&mut IntMap::with_capacity(CAP)))
             }),
             measure!($total, {
                 $eM(std::hint::black_box(&mut Map::with_capacity_none(CAP)))
@@ -37,49 +37,24 @@ macro_rules! compare {
 fn benchmark(total: usize) -> Vec<(&'static str, Duration, Duration)> {
     let mut ret = vec![];
     compare!(
-        "i ∈ 0..CAP {M.insert(i, &42); s ∈ M.into_values() {sum += s}}",
-        ret,
-        total,
-        |v: &mut Vec<_>| {
-            let mut sum = 0;
-            for _ in 0..CAP {
-                v.push(&42);
-                for s in v.into_iter() {
-                    sum += *s;
-                }
-            }
-            sum
-        },
-        |v: &mut Map<_>| {
-            let mut sum = 0;
-            for i in 0..CAP {
-                v.insert(i, &42);
-                for s in v.into_values() {
-                    sum += *s;
-                }
-            }
-            sum
-        }
-    );
-    compare!(
         "i ∈ 0..CAP {M.insert(i, &42); s ∈ M.values() {sum += s}}",
         ret,
         total,
-        |v: &mut Vec<_>| {
+        |mi: &mut FastIntMap| {
             let mut sum = 0;
-            for _ in 0..CAP {
-                v.push(&42);
-                for s in v.iter() {
+            for i in 0..CAP as u64 {
+                mi.insert(i, &42);
+                for s in mi.values() {
                     sum += *s;
                 }
             }
             sum
         },
-        |v: &mut Map<_>| {
+        |m: &mut Map<_>| {
             let mut sum = 0;
             for i in 0..CAP {
-                v.insert(i, &42);
-                for s in v.values() {
+                m.insert(i, &42);
+                for s in m.values() {
                     sum += *s;
                 }
             }
@@ -90,21 +65,21 @@ fn benchmark(total: usize) -> Vec<(&'static str, Duration, Duration)> {
         "i ∈ 0..CAP {M.insert(i, &\"大家好\"); s ∈ M.values() {sum += s.len()}}",
         ret,
         total,
-        |v: &mut Vec<_>| {
+        |mi: &mut FastIntMapStr| {
             let mut sum = 0;
-            for _ in 0..CAP {
-                v.push(&"大家好");
-                for s in v.iter() {
+            for i in 0..CAP as u64 {
+                mi.insert(i, &"大家好");
+                for s in mi.values() {
                     sum += s.len();
                 }
             }
             sum
         },
-        |v: &mut Map<_>| {
+        |m: &mut Map<_>| {
             let mut sum = 0;
             for i in 0..CAP {
-                v.insert(i, &"大家好");
-                for s in v.values() {
+                m.insert(i, &"大家好");
+                for s in m.values() {
                     sum += s.len();
                 }
             }
@@ -115,21 +90,21 @@ fn benchmark(total: usize) -> Vec<(&'static str, Duration, Duration)> {
         "i ∈ 0..CAP {M.insert(i, &42); s ∈ M.keys() {sum += s}}",
         ret,
         total,
-        |v: &mut Vec<_>| {
+        |mi: &mut FastIntMap| {
             let mut sum = 0;
-            for _ in 0..CAP {
-                v.push(&42);
-                for s in v.iter() {
-                    sum += *s;
+            for i in 0..CAP as u64 {
+                mi.insert(i, &42);
+                for k in mi.keys() {
+                    sum += k;
                 }
             }
             sum
         },
-        |v: &mut Map<_>| {
+        |m: &mut Map<_>| {
             let mut sum = 0;
             for i in 0..CAP {
-                v.insert(i, &42);
-                for k in v.keys() {
+                m.insert(i, &42);
+                for k in m.keys() {
                     sum += k;
                 }
             }
@@ -140,20 +115,20 @@ fn benchmark(total: usize) -> Vec<(&'static str, Duration, Duration)> {
         "i ∈ 0..CAP {M.insert(i, &42)}; i ∈ CAP-1..0 {M.remove(&i)}",
         ret,
         total,
-        |v: &mut Vec<_>| {
-            for _ in 0..CAP {
-                v.push(&42);
+        |mi: &mut FastIntMap| {
+            for i in 0..CAP as u64 {
+                mi.insert(i, &42);
             }
-            for i in CAP - 1..0 {
-                v.remove(i);
+            for i in 0..CAP as u64 {
+                mi.remove(i);
             }
         },
-        |v: &mut Map<_>| {
+        |m: &mut Map<_>| {
             for i in 0..CAP {
-                v.insert(i, &42);
+                m.insert(i, &42);
             }
-            for i in CAP - 1..0 {
-                v.remove(i);
+            for i in 0..CAP {
+                m.remove(i);
             }
         }
     );
@@ -161,33 +136,33 @@ fn benchmark(total: usize) -> Vec<(&'static str, Duration, Duration)> {
         "i ∈ 0..CAP {M.insert(i, &42)}; M.clear(); M.len();",
         ret,
         total,
-        |v: &mut Vec<_>| {
-            for _ in 0..CAP {
-                v.push(&42);
+        |mi: &mut FastIntMap| {
+            for i in 0..CAP as u64 {
+                mi.insert(i, &42);
             }
-            v.clear();
-            v.len()
+            mi.clear();
+            mi.len()
         },
-        |v: &mut Map<_>| {
+        |m: &mut Map<_>| {
             for i in 0..CAP {
-                v.insert(i, &42);
+                m.insert(i, &42);
             }
-            v.clear();
-            v.len()
+            m.clear();
+            m.len()
         }
     );
     compare!(
         "i ∈ 0..CAP {M.insert(i, &\"Hello, world!\")}",
         ret,
         total,
-        |v: &mut Vec<_>| {
-            for _ in 0..CAP {
-                v.push(&"Hello, world!");
+        |mi: &mut FastIntMapStr| {
+            for i in 0..CAP as u64 {
+                mi.insert(i, &"Hello, world!");
             }
         },
-        |v: &mut Map<_>| {
+        |m: &mut Map<_>| {
             for i in 0..CAP {
-                v.insert(i, &"Hello, world!");
+                m.insert(i, &"Hello, world!");
             }
         }
     );
@@ -202,9 +177,9 @@ fn benchmark(total: usize) -> Vec<(&'static str, Duration, Duration)> {
 #[test]
 pub fn benchmark_and_print() {
     let times = benchmark(1000);
-    for (m, dv, dm) in times {
-        println!("{m} -> {:.2}x", dv.as_nanos() as f64 / dm.as_nanos() as f64);
-        assert!(dv.as_nanos() > 0);
+    for (m, di, dm) in times {
+        println!("{m} -> {:.2}x", di.as_nanos() as f64 / dm.as_nanos() as f64);
+        assert!(di.as_nanos() > 0);
     }
 }
 
@@ -212,8 +187,8 @@ pub fn main() {
     let args: Vec<String> = env::args().collect();
     let times = benchmark(args.get(1).unwrap().parse::<usize>().unwrap());
     let mut lines = vec![];
-    for (m, dv, dm) in times {
-        lines.push(format!("{m}\t{}\t{}", dv.as_nanos(), dm.as_nanos()));
+    for (m, di, dm) in times {
+        lines.push(format!("{m}\t{}\t{}", di.as_nanos(), dm.as_nanos()));
     }
     lines.sort();
     for t in lines {


### PR DESCRIPTION
@yegor256 
As we discussed, I've changed the benchmarks. Now, instead of comparing with `Vec`, we comparing with `IntMap`.