### PR TITLE
perf: make `Map::len` O(1)

### DIFF
--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -30,6 +30,7 @@ impl<V> Map<V> {
                 first_used: NodeId::new(NodeId::UNDEF),
                 layout,
                 head: ptr.cast(),
+                len: 0,
                 #[cfg(debug_assertions)]
                 initialized: false,
             }
@@ -93,6 +94,7 @@ impl<V: Clone> Map<V> {
     pub fn with_capacity_some(cap: usize, v: V) -> Self {
         let mut m = Self::with_capacity(cap);
         m.init_with_some(cap, v);
+        m.len = cap;
         #[cfg(debug_assertions)]
         {
             m.initialized = true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub struct Map<V> {
     first_used: NodeId, // head of elements list
     head: *mut Node<V>,
     layout: Layout,
+    len: usize,
     #[cfg(debug_assertions)]
     initialized: bool,
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -21,13 +21,7 @@ impl<V> Map<V> {
     pub fn len(&self) -> usize {
         #[cfg(debug_assertions)]
         assert!(self.initialized, "Can't do len() on non-initialized Map");
-        let mut busy = 0;
-        for i in 0..self.capacity() {
-            if self.get(i).is_some() {
-                busy += 1;
-            }
-        }
-        busy
+        self.len
     }
 
     /// Does the map contain this key?
@@ -90,6 +84,7 @@ impl<V> Map<V> {
 
         self.first_free = NodeId::new(k);
         node.replace_value(None);
+        self.len -= 1;
     }
 
     /// Push to the rightmost position and return the key.
@@ -97,6 +92,7 @@ impl<V> Map<V> {
     pub fn push(&mut self, v: V) -> usize {
         let k = self.next_key();
         self.insert(k, v);
+        self.len += 1;
         k
     }
 
@@ -142,6 +138,7 @@ impl<V> Map<V> {
 
         self.first_used = NodeId::new(k);
         node.replace_value(Some(v));
+        self.len += 1;
     }
 
     /// Get a reference to a single value.


### PR DESCRIPTION
Asqar Arslanov, B23-SD-01
a.arslanov@innopolis.university

Closes #124.

I reduced the complexity of the `Map::len` method from O(n) to O(1) by adding a private `len` field and changing it whenever new elements are added to / removed from the map.

### Drawbacks:

- The size of the `Map` struct grows from 48 bytes to 56.
- It becomes harder to maintain the type’s invariants.

### Affected functions:

- `Map::len(&self)`: just return the `len` field instead of recalculating the length.
- `Map::with_capacity()`: `len` is set to 0.
- `Map::with_capacity_none()`: reuse `Map::with_capacity`.
- `Map::with_capacity_some()`: `len` is set to `cap`.
- `Map::push(&mut self)`: increment `len` by 1 every time.
- `Map::insert(&mut self)`: increment `len` by 1 if the method doesn’t return early.
- `Map::remove(&mut self)`: decrement `len` by 1 if the method doesn’t return early.


There don’t seem to be any other public methods that can change the length of a map.

All tests are passing.