### PR TITLE
fix: restore safe iterator lifetimes and bincode compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,23 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bincode"
-version = "3.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6a120d2e16b3e1b4a24bd70f23b12d3e16b81f113364a26935f8db7245452d"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
 
 [[package]]
 name = "bumpalo"
@@ -500,6 +514,18 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,22 +40,11 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bincode"
-version = "2.0.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "bincode_derive",
  "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
 ]
 
 [[package]]
@@ -514,18 +503,6 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
-
-[[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ intmap = "3.1.0"
 serde = { version = "1.0.185", optional = true, default-features = false }
 
 [dev-dependencies]
-bincode = "3.0.0"
+bincode = "2.0.0-rc.3"
 paste = "1.0"
 criterion = { version = "0.8", features = ["html_reports"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ intmap = "3.1.0"
 serde = { version = "1.0.185", optional = true, default-features = false }
 
 [dev-dependencies]
-bincode = "2.0.0-rc.3"
+bincode = "1.3.3"
 paste = "1.0"
 criterion = { version = "0.8", features = ["html_reports"] }
 

--- a/benches/compare_with_intmap.rs
+++ b/benches/compare_with_intmap.rs
@@ -89,27 +89,35 @@ fn compare_ctors_prefill(c: &mut Criterion) {
     for &size in SIZES {
         group.throughput(Throughput::Elements(size as u64));
 
-        group.bench_with_input(BenchmarkId::new("intmap_ctor+fill", size), &size, |b, &n| {
-            b.iter(|| {
-                let mut m = IntMapI32::with_capacity(n);
-                let v = black_box(42_i32);
-                for i in 0..n {
-                    m.insert(i, v);
-                }
-                black_box(m);
-            });
-        });
+        group.bench_with_input(
+            BenchmarkId::new("intmap_ctor+fill", size),
+            &size,
+            |b, &n| {
+                b.iter(|| {
+                    let mut m = IntMapI32::with_capacity(n);
+                    let v = black_box(42_i32);
+                    for i in 0..n {
+                        m.insert(i, v);
+                    }
+                    black_box(m);
+                });
+            },
+        );
 
-        group.bench_with_input(BenchmarkId::new("emap_ctor+fill_safe", size), &size, |b, &n| {
-            b.iter(|| {
-                let mut m = EMap::<i32>::with_capacity_none(n);
-                let v = black_box(42_i32);
-                for i in 0..n {
-                    m.insert(i, v);
-                }
-                black_box(m);
-            });
-        });
+        group.bench_with_input(
+            BenchmarkId::new("emap_ctor+fill_safe", size),
+            &size,
+            |b, &n| {
+                b.iter(|| {
+                    let mut m = EMap::<i32>::with_capacity_none(n);
+                    let v = black_box(42_i32);
+                    for i in 0..n {
+                        m.insert(i, v);
+                    }
+                    black_box(m);
+                });
+            },
+        );
 
         group.bench_with_input(
             BenchmarkId::new("emap_ctor+fill_unchecked", size),
@@ -220,21 +228,25 @@ fn compare_values(c: &mut Criterion) {
             );
         });
 
-        group.bench_with_input(BenchmarkId::new("emap_values_unchecked", size), &size, |b, &n| {
-            b.iter_batched(
-                || setup_emap_prefilled_unchecked(n, 42),
-                |m| {
-                    let mut acc = 0i64;
-                    for _ in 0..PASSES {
-                        for v in m.values() {
-                            acc += black_box(*v as i64);
+        group.bench_with_input(
+            BenchmarkId::new("emap_values_unchecked", size),
+            &size,
+            |b, &n| {
+                b.iter_batched(
+                    || setup_emap_prefilled_unchecked(n, 42),
+                    |m| {
+                        let mut acc = 0i64;
+                        for _ in 0..PASSES {
+                            for v in m.values() {
+                                acc += black_box(*v as i64);
+                            }
                         }
-                    }
-                    black_box(acc);
-                },
-                BatchSize::SmallInput,
-            );
-        });
+                        black_box(acc);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
     }
     group.finish();
 }

--- a/benches/insert.rs
+++ b/benches/insert.rs
@@ -7,7 +7,7 @@ use std::hint::black_box;
 use std::time::Duration;
 
 use criterion::{
-    criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, SamplingMode, Throughput,
+    BatchSize, BenchmarkId, Criterion, SamplingMode, Throughput, criterion_group, criterion_main,
 };
 use emap::Map;
 

--- a/benches/remove.rs
+++ b/benches/remove.rs
@@ -7,8 +7,8 @@ use std::hint::black_box;
 use std::time::Duration;
 
 use criterion::{
-    criterion_group, criterion_main, measurement::WallTime, BatchSize, BenchmarkGroup, BenchmarkId,
-    Criterion, SamplingMode, Throughput,
+    BatchSize, BenchmarkGroup, BenchmarkId, Criterion, SamplingMode, Throughput, criterion_group,
+    criterion_main, measurement::WallTime,
 };
 use emap::Map;
 
@@ -48,7 +48,7 @@ fn bench_remove_safe<T: Copy + 'static>(
             || setup_prefilled_map(value),
             |mut m| {
                 for i in 0..CAPACITY {
-                    let _ = m.remove(i);
+                    m.remove(i);
                 }
                 black_box(m);
             },

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -50,7 +50,9 @@ struct Foo {
 #[test]
 #[ignore]
 fn clone_of_wrapper() {
-    let mut f: Foo = Foo { m: Map::with_capacity_none(16) };
+    let mut f: Foo = Foo {
+        m: Map::with_capacity_none(16),
+    };
     f.m.insert(7, 42);
     assert_eq!(1, f.clone().m.len());
 }

--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -344,15 +344,17 @@ mod tests {
     impl PanicOnClone {
         fn new(panic_after: usize, clones: Rc<Cell<usize>>, active: Rc<Cell<usize>>) -> Self {
             active.set(active.get() + 1);
-            Self { clones, active, panic_after }
+            Self {
+                clones,
+                active,
+                panic_after,
+            }
         }
     }
 
     impl Clone for PanicOnClone {
         fn clone(&self) -> Self {
-            if self.clones.get() >= self.panic_after {
-                panic!("clone limit reached");
-            }
+            assert!(self.clones.get() < self.panic_after, "clone limit reached");
             self.clones.set(self.clones.get() + 1);
             self.active.set(self.active.get() + 1);
             Self {

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -44,7 +44,7 @@ impl<'a, V: Clone + 'a> Iterator for IterMut<'a, V> {
     }
 }
 
-impl<V: Clone> Iterator for IntoIter<V> {
+impl<'a, V: Clone + 'a> Iterator for IntoIter<'a, V> {
     type Item = (usize, V);
 
     #[inline]
@@ -60,13 +60,13 @@ impl<V: Clone> Iterator for IntoIter<V> {
     }
 }
 
-impl<V: Clone> IntoIterator for &Map<V> {
+impl<'a, V: Clone> IntoIterator for &'a Map<V> {
     type Item = (usize, V);
-    type IntoIter = IntoIter<V>;
+    type IntoIter = IntoIter<'a, V>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        IntoIter { current: self.first_used, head: self.head }
+        IntoIter { current: self.first_used, head: self.head, _marker: PhantomData }
     }
 }
 
@@ -117,10 +117,10 @@ impl<V: Clone> Map<V> {
     /// It may panic in debug mode, if the [`Map`] is not initialized.
     #[inline]
     #[must_use]
-    pub const fn into_iter(&self) -> IntoIter<V> {
+    pub const fn into_iter(&self) -> IntoIter<'_, V> {
         #[cfg(debug_assertions)]
         assert!(self.initialized, "Can't into_iter() non-initialized Map");
-        IntoIter { current: self.first_used, head: self.head }
+        IntoIter { current: self.first_used, head: self.head, _marker: PhantomData }
     }
 }
 

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -66,7 +66,11 @@ impl<'a, V: Clone> IntoIterator for &'a Map<V> {
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        IntoIter { current: self.first_used, head: self.head, _marker: PhantomData }
+        IntoIter {
+            current: self.first_used,
+            head: self.head,
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -81,7 +85,11 @@ impl<V: Clone> Map<V> {
     pub const fn iter(&self) -> Iter<'_, V> {
         #[cfg(debug_assertions)]
         assert!(self.initialized, "Can't iter() non-initialized Map");
-        Iter { current: self.first_used, head: self.head, _marker: PhantomData }
+        Iter {
+            current: self.first_used,
+            head: self.head,
+            _marker: PhantomData,
+        }
     }
     /// Make a mutable iterator over all items.
     ///
@@ -107,7 +115,11 @@ impl<V: Clone> Map<V> {
     pub const fn iter_mut(&self) -> IterMut<'_, V> {
         #[cfg(debug_assertions)]
         assert!(self.initialized, "Can't iter_mut() non-initialized Map");
-        IterMut { current: self.first_used, head: self.head, _marker: PhantomData }
+        IterMut {
+            current: self.first_used,
+            head: self.head,
+            _marker: PhantomData,
+        }
     }
 
     /// Make an iterator over all items.
@@ -120,7 +132,11 @@ impl<V: Clone> Map<V> {
     pub const fn into_iter(&self) -> IntoIter<'_, V> {
         #[cfg(debug_assertions)]
         assert!(self.initialized, "Can't into_iter() non-initialized Map");
-        IntoIter { current: self.first_used, head: self.head, _marker: PhantomData }
+        IntoIter {
+            current: self.first_used,
+            head: self.head,
+            _marker: PhantomData,
+        }
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -3,10 +3,10 @@
 
 use crate::Keys;
 use crate::Map;
-use std::mem;
 use std::marker::PhantomData;
+use std::mem;
 
-impl<'a, V> Iterator for Keys<'a, V> {
+impl<V> Iterator for Keys<'_, V> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -31,7 +31,11 @@ impl<V> Map<V> {
     pub const fn keys(&self) -> Keys<'_, V> {
         #[cfg(debug_assertions)]
         assert!(self.initialized, "Can't keys() non-initialized Map");
-        Keys { current: self.first_used, head: self.head, _marker: PhantomData }
+        Keys {
+            current: self.first_used,
+            head: self.head,
+            _marker: PhantomData,
+        }
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -4,8 +4,9 @@
 use crate::Keys;
 use crate::Map;
 use std::mem;
+use std::marker::PhantomData;
 
-impl<V> Iterator for Keys<V> {
+impl<'a, V> Iterator for Keys<'a, V> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -27,10 +28,10 @@ impl<V> Map<V> {
     /// It may panic in debug mode, if the [`Map`] is not initialized.
     #[inline]
     #[must_use]
-    pub const fn keys(&self) -> Keys<V> {
+    pub const fn keys(&self) -> Keys<'_, V> {
         #[cfg(debug_assertions)]
         assert!(self.initialized, "Can't keys() non-initialized Map");
-        Keys { current: self.first_used, head: self.head }
+        Keys { current: self.first_used, head: self.head, _marker: PhantomData }
     }
 }
 
@@ -144,5 +145,16 @@ mod tests {
 
         let actual_keys: HashSet<_> = map.keys().collect();
         assert_eq!(actual_keys, expected_keys);
+    }
+
+    #[test]
+    fn keys_iterator_does_not_drop_stored_value() {
+        let mut m: Map<String> = Map::with_capacity_none(16);
+        m.insert(0, String::from("hello"));
+
+        let keys: Vec<usize> = m.keys().collect();
+        assert_eq!(keys, vec![0]);
+
+        assert_eq!(m.get(0).unwrap(), "hello");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,9 +66,10 @@ pub struct IterMut<'a, V> {
 }
 
 /// Into-iterator over the [`Map`].
-pub struct IntoIter<V> {
+pub struct IntoIter<'a, V> {
     current: NodeId,
     head: *mut Node<V>,
+    _marker: PhantomData<&'a Map<V>>,
 }
 
 pub struct Values<'a, V> {
@@ -78,15 +79,17 @@ pub struct Values<'a, V> {
 }
 
 /// Into-iterator over the values of a [`Map`].
-pub struct IntoValues<V> {
+pub struct IntoValues<'a, V> {
     current: NodeId,
     head: *mut Node<V>,
+    _marker: PhantomData<&'a Map<V>>,
 }
 
 /// Iterator over the keys of a [`Map`].
-pub struct Keys<V> {
+pub struct Keys<'a, V> {
     current: NodeId,
     head: *mut Node<V>,
+    _marker: PhantomData<&'a Map<V>>,
 }
 
 #[cfg(test)]
@@ -110,7 +113,8 @@ fn perf() {
         for i in 0..cap {
             m.remove(i);
         }
-        for (k, _) in m.into_iter() {
+        let keys: Vec<usize> = m.into_iter().map(|(k, _)| k).collect();
+        for k in keys {
             m.remove(k);
         }
         for i in 0..cap {

--- a/src/map.rs
+++ b/src/map.rs
@@ -236,7 +236,8 @@ impl<V> Map<V> {
     pub fn retain<F: Fn(&usize, &V) -> bool>(&mut self, f: F) {
         #[cfg(debug_assertions)]
         assert!(self.initialized, "Can't do retain() on non-initialized Map");
-        for i in self.keys() {
+        let keys: Vec<usize> = self.keys().collect();
+        for i in keys {
             let mut should_remove = false;
             if let Some(p) = self.get_mut(i) {
                 should_remove = !f(&i, p);

--- a/src/map.rs
+++ b/src/map.rs
@@ -238,10 +238,7 @@ impl<V> Map<V> {
         assert!(self.initialized, "Can't do retain() on non-initialized Map");
         let keys: Vec<usize> = self.keys().collect();
         for i in keys {
-            let mut should_remove = false;
-            if let Some(p) = self.get_mut(i) {
-                should_remove = !f(&i, p);
-            }
+            let should_remove = self.get_mut(i).is_some_and(|p| !f(&i, p));
             if should_remove {
                 self.remove(i);
             }

--- a/src/node.rs
+++ b/src/node.rs
@@ -45,7 +45,11 @@ impl<V> Node<V> {
     #[inline]
     #[must_use]
     pub const fn new(next: usize, prev: usize, value: Option<V>) -> Self {
-        Self { next: NodeId::new(next), prev: NodeId::new(prev), value }
+        Self {
+            next: NodeId::new(next),
+            prev: NodeId::new(prev),
+            value,
+        }
     }
 
     #[inline]

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -42,7 +42,7 @@ impl<'de, V: Clone + Deserialize<'de>> Visitor<'de> for Vi<V> {
             map.insert(key, value);
         }
         let mut m: Self::Value = Map::with_capacity_none(map.len());
-        for (k, v) in map.iter() {
+        for (k, v) in &map {
             m.insert(*k, v.clone());
         }
         Ok(m)

--- a/src/values.rs
+++ b/src/values.rs
@@ -46,7 +46,11 @@ impl<V> Map<V> {
     pub const fn values(&self) -> Values<'_, V> {
         #[cfg(debug_assertions)]
         assert!(self.initialized, "Can't values() non-initialized Map");
-        Values { current: self.first_used, head: self.head, _marker: PhantomData }
+        Values {
+            current: self.first_used,
+            head: self.head,
+            _marker: PhantomData,
+        }
     }
 
     /// Make an into-iterator over all items.
@@ -59,7 +63,11 @@ impl<V> Map<V> {
     pub const fn into_values(&self) -> IntoValues<'_, V> {
         #[cfg(debug_assertions)]
         assert!(self.initialized, "Can't into_values() non-initialized Map");
-        IntoValues { current: self.first_used, head: self.head, _marker: PhantomData }
+        IntoValues {
+            current: self.first_used,
+            head: self.head,
+            _marker: PhantomData,
+        }
     }
 }
 

--- a/src/values.rs
+++ b/src/values.rs
@@ -20,7 +20,7 @@ impl<'a, V: 'a> Iterator for Values<'a, V> {
     }
 }
 
-impl<V: Clone> Iterator for IntoValues<V> {
+impl<'a, V: Clone + 'a> Iterator for IntoValues<'a, V> {
     type Item = V;
 
     #[inline]
@@ -56,10 +56,10 @@ impl<V> Map<V> {
     /// It may panic in debug mode, if the [`Map`] is not initialized.
     #[inline]
     #[must_use]
-    pub const fn into_values(&self) -> IntoValues<V> {
+    pub const fn into_values(&self) -> IntoValues<'_, V> {
         #[cfg(debug_assertions)]
         assert!(self.initialized, "Can't into_values() non-initialized Map");
-        IntoValues { current: self.first_used, head: self.head }
+        IntoValues { current: self.first_used, head: self.head, _marker: PhantomData }
     }
 }
 

--- a/tests/benchmark.rs
+++ b/tests/benchmark.rs
@@ -24,8 +24,12 @@ macro_rules! compare {
     ($title:expr, $ret:expr, $total:expr, $eI:expr, $eM:expr) => {{
         $ret.push((
             $title,
-            measure!($total, { $eI(std::hint::black_box(&mut IntMap::with_capacity(CAP))) }),
-            measure!($total, { $eM(std::hint::black_box(&mut Map::with_capacity_none(CAP))) }),
+            measure!($total, {
+                $eI(std::hint::black_box(&mut IntMap::with_capacity(CAP)))
+            }),
+            measure!($total, {
+                $eM(std::hint::black_box(&mut Map::with_capacity_none(CAP)))
+            }),
         ));
     }};
 }


### PR DESCRIPTION
## Summary
- restore iterator lifetime parameters and `PhantomData` markers so borrowed map iterators retain their borrow relation
- update `bincode` development dependency from the incompatible 3.0.0 release to 1.3.3
- apply current Rust formatting and Clippy-driven cleanups across the affected code

## Validation
- `cargo fmt --check`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings` *(currently blocked by seven pre-existing `#[ignore]` / `#[should_panic]` annotations that lack reasons; none are introduced by this branch)*