### PR TITLE
fix: restore map invariants and safe deserialization

### DIFF
--- a/benches/insert.rs
+++ b/benches/insert.rs
@@ -116,6 +116,36 @@ fn bench_insert_u64(c: &mut Criterion) {
     group.finish();
 }
 
+/// Batch-throughput benchmark: CAP pushes of a u64.
+///
+/// Setup and destruction stay outside the timed routine.
+fn bench_push_u64(c: &mut Criterion) {
+    let mut group = c.benchmark_group("emap_push_u64");
+    group.sampling_mode(SamplingMode::Flat);
+
+    let val: u64 = 42;
+
+    for &cap in SIZES {
+        group.throughput(Throughput::Elements(cap as u64));
+
+        group.bench_with_input(BenchmarkId::from_parameter(cap), &cap, |b, &n| {
+            b.iter_batched_ref(
+                || Map::<u64>::with_capacity_none(n),
+                |m| {
+                    let v = black_box(val);
+                    for _ in 0..n {
+                        m.push(v);
+                    }
+                    black_box(m);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
 /// Batch-throughput benchmark: CAP inserts of an owned `String`.
 ///
 /// This includes allocation and memcpy cost for the value payload.
@@ -189,6 +219,7 @@ criterion_group! {
     targets =
         bench_insert_str,
         bench_insert_u64,
+        bench_push_u64,
         bench_insert_string,
         bench_single_insert_latency
 }

--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -4,7 +4,7 @@
 use crate::{Map, Node, NodeId};
 use std::alloc::{Layout, alloc, dealloc, handle_alloc_error};
 use std::mem;
-use std::ptr;
+use std::ptr::{self, NonNull};
 
 impl<V> Drop for Map<V> {
     fn drop(&mut self) {
@@ -20,8 +20,10 @@ impl<V> Drop for Map<V> {
             self.drop_used_nodes();
         }
 
-        unsafe {
-            dealloc(self.head.cast(), self.layout);
+        if self.layout.size() != 0 {
+            unsafe {
+                dealloc(self.head.cast(), self.layout);
+            }
         }
     }
 }
@@ -36,15 +38,20 @@ impl<V> Map<V> {
     #[must_use]
     fn with_capacity(cap: usize) -> Self {
         let layout = Layout::array::<Node<V>>(cap).expect("invalid layout");
-        let ptr = unsafe { alloc(layout) };
-        if ptr.is_null() {
-            handle_alloc_error(layout);
-        }
+        let head = if layout.size() == 0 {
+            NonNull::<Node<V>>::dangling().as_ptr()
+        } else {
+            let ptr = unsafe { alloc(layout) };
+            if ptr.is_null() {
+                handle_alloc_error(layout);
+            }
+            ptr.cast()
+        };
         Self {
             first_free: NodeId::new(NodeId::UNDEF),
             first_used: NodeId::new(NodeId::UNDEF),
             layout,
-            head: ptr.cast(),
+            head,
             len: 0,
             #[cfg(debug_assertions)]
             initialized: false,
@@ -74,7 +81,11 @@ impl<V> Map<V> {
     #[inline]
     fn init_with_none(&mut self) {
         let cap = self.capacity();
-        self.first_free = NodeId::new(0);
+        self.first_free = if cap == 0 {
+            NodeId::new(NodeId::UNDEF)
+        } else {
+            NodeId::new(0)
+        };
         let mut p = self.head;
         for i in 0..cap {
             let free_next = if i + 1 == cap { NodeId::UNDEF } else { i + 1 };
@@ -105,7 +116,8 @@ impl<V: Clone> Map<V> {
     #[must_use]
     pub fn with_capacity_some(cap: usize, v: V) -> Self {
         let mut m = Self::with_capacity(cap);
-        m.init_with_some(cap, v);
+        // SAFETY: `m` owns a fresh allocation with no initialized nodes.
+        unsafe { m.init_fresh_with_some(v) };
         #[cfg(debug_assertions)]
         {
             m.initialized = true;
@@ -114,8 +126,33 @@ impl<V: Clone> Map<V> {
     }
 
     /// Fill all slots with `Some(v.clone())` and build the used-list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `cap` differs from this map's capacity, allocation fails, or
+    /// cloning `v` panics.
     #[inline]
     pub fn init_with_some(&mut self, cap: usize, v: V) {
+        assert_eq!(
+            cap,
+            self.capacity(),
+            "The capacity {cap} does not match the map capacity {}",
+            self.capacity()
+        );
+        let replacement = Self::with_capacity_some(cap, v);
+        let previous = mem::replace(self, replacement);
+        drop(previous);
+    }
+
+    /// Fill a fresh allocation without first initializing its nodes.
+    ///
+    /// # Safety
+    ///
+    /// Every slot in `self` must be uninitialized and `self.capacity()` must
+    /// match the allocated node array.
+    #[inline]
+    unsafe fn init_fresh_with_some(&mut self, v: V) {
+        let cap = self.capacity();
         let mut previous_used = NodeId::new(NodeId::UNDEF);
         self.first_free = NodeId::new(NodeId::UNDEF);
         self.first_used = NodeId::new(NodeId::UNDEF);
@@ -319,9 +356,50 @@ mod tests {
     /// Zero capacity must be supported.
     #[test]
     fn init_with_empty() {
-        let m: Map<Foo> = Map::with_capacity_some(0, Foo { t: 42 });
-        assert_eq!(0, m.capacity());
-        assert_eq!(0, m.len());
+        let some: Map<Foo> = Map::with_capacity_some(0, Foo { t: 42 });
+        assert_eq!(0, some.capacity());
+        assert_eq!(0, some.len());
+        assert!(catch_unwind(|| some.next_key()).is_err());
+
+        let none: Map<Foo> = Map::with_capacity_none(0);
+        assert_eq!(0, none.capacity());
+        assert_eq!(0, none.len());
+        assert!(catch_unwind(|| none.next_key()).is_err());
+    }
+
+    /// Reinitialization must cover the map's complete allocation.
+    #[test]
+    fn init_with_some_rejects_capacity_mismatch() {
+        for invalid in [1, 3] {
+            let mut map = Map::with_capacity_none(2);
+            map.insert(0, 41);
+
+            let result = catch_unwind(AssertUnwindSafe(|| {
+                map.init_with_some(invalid, 42);
+            }));
+
+            assert!(result.is_err());
+            assert_eq!(2, map.capacity());
+            assert_eq!(1, map.len());
+            assert_eq!(Some(&41), map.get(0));
+        }
+    }
+
+    /// Reinitialization must drop values that it replaces.
+    #[test]
+    fn init_with_some_drops_replaced_values() {
+        let original = Rc::new(());
+        let replacement = Rc::new(());
+        let mut map = Map::with_capacity_none(2);
+        map.insert(0, Rc::clone(&original));
+
+        map.init_with_some(2, Rc::clone(&replacement));
+
+        assert_eq!(1, Rc::strong_count(&original));
+        assert_eq!(3, Rc::strong_count(&replacement));
+        assert_eq!(2, map.len());
+        drop(map);
+        assert_eq!(1, Rc::strong_count(&replacement));
     }
 
     /// Partial initialization that panics must still be drop-safe.
@@ -370,6 +448,33 @@ mod tests {
             let current = self.active.get();
             self.active.set(current.saturating_sub(1));
         }
+    }
+
+    /// A clone panic during reinitialization must leave the old map unchanged.
+    #[test]
+    fn init_with_some_clone_panic_preserves_existing_map() {
+        let old_clones = Rc::new(Cell::new(0));
+        let old_active = Rc::new(Cell::new(0));
+        let old = PanicOnClone::new(usize::MAX, Rc::clone(&old_clones), Rc::clone(&old_active));
+        let mut map = Map::with_capacity_some(2, old);
+        assert_eq!(2, old_active.get());
+
+        let new_clones = Rc::new(Cell::new(0));
+        let new_active = Rc::new(Cell::new(0));
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let new = PanicOnClone::new(1, Rc::clone(&new_clones), Rc::clone(&new_active));
+            map.init_with_some(2, new);
+        }));
+
+        assert!(result.is_err());
+        assert_eq!(2, map.len());
+        assert_eq!(2, map.iter().count());
+        assert_eq!(2, old_active.get());
+        assert_eq!(0, new_active.get());
+
+        drop(map);
+        assert_eq!(0, old_active.get());
+        assert_eq!(0, new_active.get());
     }
 
     /// If cloning panics during `with_capacity_some`, no values must leak.

--- a/src/map.rs
+++ b/src/map.rs
@@ -104,8 +104,8 @@ impl<V> Map<V> {
 
         self.first_free = NodeId::new(k);
         let previous = node.replace_value(None);
-        drop(previous);
         self.len -= 1;
+        drop(previous);
     }
 
     /// Push to the rightmost position and return the key.
@@ -113,7 +113,6 @@ impl<V> Map<V> {
     pub fn push(&mut self, v: V) -> usize {
         let k = self.next_key();
         self.insert(k, v);
-        self.len += 1;
         k
     }
 
@@ -368,6 +367,32 @@ fn replacing_value_drops_old_reference() {
     assert_eq!(Rc::strong_count(&replacement), 1);
 }
 
+#[test]
+fn remove_preserves_length_if_value_drop_panics() {
+    use std::cell::Cell;
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+    use std::rc::Rc;
+
+    struct PanicOnDrop(Rc<Cell<bool>>);
+
+    impl Drop for PanicOnDrop {
+        fn drop(&mut self) {
+            assert!(!self.0.replace(false), "drop panic");
+        }
+    }
+
+    let mut map = Map::with_capacity_none(1);
+    map.insert(0, PanicOnDrop(Rc::new(Cell::new(true))));
+
+    let result = catch_unwind(AssertUnwindSafe(|| map.remove(0)));
+
+    assert!(result.is_err());
+    assert_eq!(0, map.len());
+    assert!(map.is_empty());
+    assert!(!map.contains_key(0));
+    assert_eq!(0, map.next_key());
+}
+
 #[cfg(test)]
 #[derive(Clone, Copy)]
 struct Foo {
@@ -400,7 +425,14 @@ fn clears_it_up() {
 fn pushes_into() {
     let mut m: Map<&str> = Map::with_capacity_none(16);
     assert_eq!(0, m.push("one"));
+    assert_eq!(1, m.len());
     assert_eq!(1, m.push("two"));
+    assert_eq!(2, m.len());
+    assert_eq!(m.len(), m.iter().count());
+    m.remove(0);
+    assert_eq!(1, m.len());
+    m.clear();
+    assert_eq!(0, m.len());
 }
 
 #[test]

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023-2026 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
-use crate::Map;
-use serde::de::{MapAccess, Visitor};
+use crate::{Map, Node};
+use serde::de::{Error as _, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::alloc::Layout;
 use std::collections::HashMap;
 use std::fmt::Formatter;
 use std::marker::PhantomData;
@@ -26,7 +27,7 @@ impl<V: Clone + Serialize> Serialize for Map<V> {
 
 struct Vi<V>(PhantomData<V>);
 
-impl<'de, V: Clone + Deserialize<'de>> Visitor<'de> for Vi<V> {
+impl<'de, V: Deserialize<'de>> Visitor<'de> for Vi<V> {
     type Value = Map<V>;
 
     fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
@@ -37,19 +38,26 @@ impl<'de, V: Clone + Deserialize<'de>> Visitor<'de> for Vi<V> {
     where
         M: MapAccess<'de>,
     {
-        let mut map: HashMap<usize, V> = HashMap::new();
-        while let Some((key, value)) = access.next_entry()? {
+        let mut entries: HashMap<usize, V> = HashMap::new();
+        let mut required_capacity = 0;
+        while let Some((key, value)) = access.next_entry::<usize, V>()? {
+            let capacity = key
+                .checked_add(1)
+                .ok_or_else(|| M::Error::custom("emap key cannot fit into a map capacity"))?;
+            required_capacity = required_capacity.max(capacity);
+            entries.insert(key, value);
+        }
+        Layout::array::<Node<V>>(required_capacity)
+            .map_err(|_| M::Error::custom("emap capacity exceeds the maximum allocation size"))?;
+        let mut map = Map::with_capacity_none(required_capacity);
+        for (key, value) in entries {
             map.insert(key, value);
         }
-        let mut m: Self::Value = Map::with_capacity_none(map.len());
-        for (k, v) in &map {
-            m.insert(*k, v.clone());
-        }
-        Ok(m)
+        Ok(map)
     }
 }
 
-impl<'de, V: Clone + Deserialize<'de>> Deserialize<'de> for Map<V> {
+impl<'de, V: Deserialize<'de>> Deserialize<'de> for Map<V> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -80,4 +88,90 @@ fn serde_big_map() {
     let bytes: Vec<u8> = serialize(&before).unwrap();
     let after: Map<u8> = deserialize(&bytes).unwrap();
     assert_eq!(2, after.capacity());
+}
+
+#[test]
+fn serde_empty_map_uses_zero_capacity() {
+    let before: Map<u8> = Map::with_capacity_none(16);
+
+    let bytes: Vec<u8> = serialize(&before).unwrap();
+    let after: Map<u8> = deserialize(&bytes).unwrap();
+
+    assert_eq!(0, after.capacity());
+    assert_eq!(0, after.len());
+}
+
+#[test]
+fn serde_sparse_keys_preserve_values() {
+    let mut before: Map<u8> = Map::with_capacity_none(512);
+    before.insert(1, 41);
+    before.insert(255, 42);
+
+    let bytes: Vec<u8> = serialize(&before).unwrap();
+    let after: Map<u8> = deserialize(&bytes).unwrap();
+
+    assert_eq!(256, after.capacity());
+    assert_eq!(2, after.len());
+    assert_eq!(Some(&41), after.get(1));
+    assert_eq!(Some(&42), after.get(255));
+}
+
+#[test]
+fn serde_rejects_key_that_cannot_fit_capacity() {
+    use serde::de::value::{Error, MapDeserializer};
+
+    let entries = [(usize::MAX, 42_u8)];
+    let deserializer = MapDeserializer::<_, Error>::new(entries.into_iter());
+    let result = Map::<u8>::deserialize(deserializer);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn serde_rejects_key_whose_node_array_layout_overflows() {
+    use serde::de::value::{Error, MapDeserializer};
+
+    let capacity = (isize::MAX as usize / size_of::<crate::Node<u8>>()) + 1;
+    let entries = [(capacity - 1, 42_u8)];
+    let deserializer = MapDeserializer::<_, Error>::new(entries.into_iter());
+    let result = Map::<u8>::deserialize(deserializer);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn serde_duplicate_keys_keep_last_value() {
+    use serde::de::value::{Error, MapDeserializer};
+
+    let entries = [(3_usize, 41_u8), (3, 42)];
+    let deserializer = MapDeserializer::<_, Error>::new(entries.into_iter());
+    let map = Map::<u8>::deserialize(deserializer).unwrap();
+
+    assert_eq!(4, map.capacity());
+    assert_eq!(1, map.len());
+    assert_eq!(Some(&42), map.get(3));
+}
+
+#[test]
+fn serde_deserializes_values_without_clone() {
+    use serde::de::value::{Error, MapDeserializer};
+
+    struct NonClone(u8);
+
+    impl<'de> Deserialize<'de> for NonClone {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            u8::deserialize(deserializer).map(Self)
+        }
+    }
+
+    let entries = [(7_usize, 42_u8)];
+    let deserializer = MapDeserializer::<_, Error>::new(entries.into_iter());
+    let map = Map::<NonClone>::deserialize(deserializer).unwrap();
+
+    assert_eq!(8, map.capacity());
+    assert_eq!(1, map.len());
+    assert_eq!(Some(42), map.get(7).map(|value| value.0));
 }


### PR DESCRIPTION
## Summary

- keep `len` synchronized after `push` and after a removed value's destructor panics
- make zero-capacity construction conform to the allocator contract
- make `init_with_some` reject capacity mismatches, drop replaced values, and preserve the old map if cloning panics
- deserialize sparse keys with a checked `max_key + 1` capacity while preserving last-write-wins duplicates
- remove the unnecessary `Clone` bound from `Deserialize`
- add focused regression coverage and a teardown-free `push` throughput benchmark

All existing public method signatures and the serialized wire format remain unchanged.

## Root causes

- `push` incremented `len` after `insert` had already incremented it.
- `remove_unchecked` dropped the removed value before committing the new length.
- zero-capacity maps passed a zero-sized layout to `alloc` and `dealloc`.
- public `init_with_some` trusted an independent capacity, overwrote initialized values, and could leave partially rebuilt lists after a clone panic.
- the Serde visitor allocated by entry count instead of the largest key.

The regression tests were observed failing before the production fixes. In
particular, Miri reported `Undefined Behavior: creating allocation with size 0`,
one `push` produced `len == 2`, sparse deserialization panicked at key 255, and
destructor/clone panics left stale map metadata.

## Validation

- `cargo test -vv`
- `cargo test --all-features --locked` — 104 passed, 3 ignored; integration test and 2 doctests passed
- `cargo test --release --all-features --locked` — 101 passed, 3 ignored; integration test and 2 doctests passed
- `cargo test --no-default-features --locked` — 96 passed, 3 ignored; integration test and 2 doctests passed
- `cargo fmt --check`
- `cargo clippy --no-deps`
- `cargo doc --no-deps`
- `cargo check --all-targets --all-features --locked`
- `cargo bench --all-features --no-run`
- `MIRIFLAGS='-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check' cargo +nightly miri test --all-features --lib -- --skip perf` — 103 passed, 3 ignored
- `cargo +nightly llvm-cov --all-features --branch` — 96.87% lines, 94.64% branches

The stricter `cargo clippy --all-targets --all-features -- -D warnings` remains
blocked on current `master` by seven pre-existing test-attribute lints. The
project's merge-gate command above passes.

## Performance

The same `iter_batched_ref` harness was run against current `master` and this
branch. Allocation and `Map` destruction are outside the timed routine.

| pushes | master | this branch | delta |
| ---: | ---: | ---: | ---: |
| 16,384 | 85.457 us | 85.021 us | -0.51% |
| 32,768 | 170.050 us | 167.631 us | -1.42% |
| 65,536 | 336.946 us | 336.866 us | -0.02% |
| 131,072 | 670.886 us | 669.199 us | -0.25% |

No `push` throughput regression was observed.

## Related

#155 contains older, much broader work in the same areas, but it is currently
conflicting and changes public APIs. This PR is based on current `master`,
keeps the existing API, and adds focused panic-safety and Miri coverage.

## Known limitation

A layout-valid but extremely large sparse key can still request a very large
allocation. A caller-configurable `DeserializeSeed` capacity limit would be a
separate compatibility-preserving hardening step; an arbitrary global limit is
intentionally not introduced here.
